### PR TITLE
Initial work to test Colosseum against W3C CSS test suite

### DIFF
--- a/colosseum/declaration.py
+++ b/colosseum/declaration.py
@@ -15,7 +15,8 @@ def css_property(name, choices=None, default=None):
     def setter(self, value):
         if value != getattr(self, '_%s' % name, default):
             if choices and value not in choices:
-                raise InvalidCSSStyleException("Invalid value for CSS property '%s'; Valid values are: %s" % (
+                raise InvalidCSSStyleException("Invalid value '%s' for CSS property '%s'; Valid values are: %s" % (
+                    value,
                     name,
                     ', '.join(s.replace('-', '_').upper() for s in choices))
                 )

--- a/tests/get_w3c_test_data.py
+++ b/tests/get_w3c_test_data.py
@@ -1,0 +1,99 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import json
+from time import time
+from subprocess import check_output
+from os import chdir
+from os.path import abspath, join, split
+from sys import argv
+
+from colosseum.declaration import _CSS_PROPERTIES
+from selenium import webdriver
+
+SCRIPT = """
+    var el = arguments[0]
+    var style = window.getComputedStyle(el)
+    var style_obj = {}
+    for (var i = 0; i < style.length; i++){
+        style_obj[style[i]] = style.getPropertyValue(style[i])
+    }
+    return style_obj
+"""
+
+def _get_filtered_style(driver, element):
+    """Get the style attributes we care about for a given element."""
+    css = driver.execute_script(SCRIPT, element)
+    return {k: v for k, v in css.items() if k in _CSS_PROPERTIES}
+
+def _get_node_data(driver, element, x_offset, y_offset):
+    """Recursively get node_data for an element and its children."""
+    position = element.rect
+    position['left'] = position['x'] - x_offset
+    position['top'] = position['y'] - y_offset
+    del position['x']
+    del position['y']
+    return {
+        'style': _get_filtered_style(driver, element),
+        'position': position,
+        'children': [_get_node_data(driver, child, x_offset, y_offset) 
+                     for child in element.find_elements_by_xpath("./*")],
+    }
+
+def get_test_data(driver, url, root_selector, w3c_root, w3c_path, w3c_sha):
+    url = "file://{}/{}".format(w3c_root, w3c_path)
+    
+
+class TestDataGetter(object):
+    tests = [
+        ('css-flexbox-1/align-content-001.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content-002.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content-003.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content-004.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content-005.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content-006.htm', 'div#flexbox'),
+        ('css-flexbox-1/align-content_center.html', 'div#test'),
+        ('css-flexbox-1/align-content_flex-end.html', 'div#test'),
+        ('css-flexbox-1/align-content_flex-start.html', 'div#test'),
+    ]
+
+    def __init__(self, w3c_root, output_dir):
+        self.w3c_root = w3c_root
+        self.output_dir = output_dir
+        sha_bytes = check_output(('git', 'rev-parse', 'HEAD'), cwd=w3c_root)
+        self.w3c_sha = sha_bytes.decode('utf8').strip()
+    
+    def fetch_single_test(self, driver, w3c_path, root_selector):
+        url = "file://{}/{}".format(abspath(self.w3c_root), w3c_path)
+        driver.get(url)
+        root_element = driver.find_elements_by_css_selector(root_selector)[0]
+        location = root_element.location
+        x_offset, y_offset = location['x'], location['y']
+
+        return {
+            'capabilities': driver.capabilities,
+            'node_data': _get_node_data(driver, root_element, x_offset, y_offset),
+            'stored_time': time(),
+            'w3c_path': w3c_path,
+            'w3c_sha': self.w3c_sha,
+        }
+
+    def run(self):
+        driver = webdriver.Firefox()
+        try:
+            for path, selector in self.tests:
+                print("Generating {}".format(path))
+                test_data = self.fetch_single_test(driver, path, selector)
+                path = join(self.output_dir, path.replace('/', '_')) + '.json'
+                with open(path, 'w') as f:
+                    json.dump(test_data, f, indent=4, sort_keys=True)
+        finally:
+            driver.close()
+
+def main():
+    output_dir = join(split(__file__)[0], 'w3c_test_data')
+    data = TestDataGetter(argv[1], output_dir).run()
+    print(json.dumps(data, indent=4))
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -118,25 +118,24 @@ class LayoutEngineW3CTestSequenceMeta(type):
 
     @classmethod
     def getDefinition(mcs, fname):
-        """Read definitions in a .json file"""
+        """Read test definition from a .json file"""
         path = os.path.join(mcs.definitions_dir, fname)
         with open(path, 'r') as fd:
-            descriptions = json.loads(fd.read())
+            definition = json.loads(fd.read())
 
-        for description in descriptions:
-            description['name'] = fname[:-len(mcs.definitions_ext)]
+        definition['name'] = fname[:-len(mcs.definitions_ext)]
 
-        return descriptions
+        return definition
 
     @classmethod
     def getDefinitions(mcs):
         """Read all .json files in `mcs.definitions_dir`"""
-        test_files = [f for f in os.listdir(mcs.definitions_dir)
-                      if f.endswith(mcs.definitions_ext)]
+        definitions_files = [f for f in os.listdir(mcs.definitions_dir)
+                             if f.endswith(mcs.definitions_ext)]
 
         definitions = []
-        for fname in test_files:
-            definitions.extend(mcs.getDefinition(fname))
+        for fname in definitions_files:
+            definitions.append(mcs.getDefinition(fname))
 
         return definitions
 

--- a/tests/w3c_test_data/Flexible-order.html.json
+++ b/tests/w3c_test_data/Flexible-order.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 200,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 0,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 400,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 600
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313305.061652,
+    "w3c_path": "css-flexbox-1/Flexible-order.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/README.md
+++ b/tests/w3c_test_data/README.md
@@ -13,6 +13,7 @@ W3C tests are defined as:
 
 __Do this regularly__:
 
+0. Install `selenium`.
 1. Run `tests/get_w3c_test_data.py TEST_DIR`, where `TEST_DIR` is the path to a checkout of `https://github.com/w3c/csswg-test`. This will:
     1. Use `Selenium` to launch a browser to interpret CSS and render:
         1. Pull attribute/value pairs as test inputs

--- a/tests/w3c_test_data/README.md
+++ b/tests/w3c_test_data/README.md
@@ -13,7 +13,7 @@ W3C tests are defined as:
 
 __Do this regularly__:
 
-1. Loop over tests defined in `https://github.com/w3c/csswg-test`
+1. Run `get_w3c_test_data.py`, loop over tests defined in `https://github.com/w3c/csswg-test`:
     1. Use `Selenium` to launch a browser to interpret CSS and render:
         1. Pull attribute/value pairs as test inputs
         2. Pull width/height/x/y as test outputs
@@ -31,79 +31,20 @@ __Do this every time the test suite is run__:
 # Definitions Schema
 
 The definitions are stored as JSON files on disk. Each file is in essence a
-list of dicts where each dict has the following specification:
+dict with the following keys:
 
 | field | description |
 | :---- | :---------- |
 | capabilities | Selenium output, obtain from `driver.capabilities` |
-| node_data | test descriptions, a tree of nodes where each node contains three keys, `children` is a list of children nodes, `position` is a dict with keys `height`, `left`, `top` and `width`, and `style` is a list of key-value pairs of allowed style keywords. |
+| node_data | test definition, see sub-items |
+| node_data.style | key-value pairs of the CSS style to be applied to the node |
+| node_data.position | key-value pairs with keys for 'width', 'height', 'top', 'left' |
+| node_data.children | a list of nodes with the same specification as `node_data`. For nodes without children, use an empty list. |
 | stored_time | linux timestamp |
 | w3c_path | path of the W3C CSS test file relative to the root of the `csswg-test` repo |
 | w3c_sha | Commit SHA of the `csswg-test` repo at the time of definitions generation |
 
 # Example Definition
 
-```
-[
-    {
-        "capabilities": {},
-        "node_data": {
-            "children": [
-                {
-                    "children": [],
-                    "position": {
-                        "height": 500,
-                        "left": 0,
-                        "top": 0,
-                        "width": 500
-                    },
-                    "style": {
-                        "height": 500,
-                        "width": 500
-                    }
-                },
-                {
-                    "children": [],
-                    "position": {
-                        "height": 250,
-                        "left": 0,
-                        "top": 500,
-                        "width": 250
-                    },
-                    "style": {
-                        "height": 250,
-                        "width": 250
-                    }
-                },
-                {
-                    "children": [],
-                    "position": {
-                        "height": 125,
-                        "left": 0,
-                        "top": 750,
-                        "width": 125
-                    },
-                    "style": {
-                        "height": 125,
-                        "width": 125
-                    }
-                }
-            ],
-            "position": {
-                "height": 1000,
-                "left": 0,
-                "top": 0,
-                "width": 1000
-            },
-            "style": {
-                "height": 1000,
-                "width": 1000
-            }
-        },
-        "stored_time": 1471228060,
-        "w3c_path": "css-flexbox-1/align-content-001.htm",
-        "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
-    },
-    ...
-]
-```
+See `example.json`, which implements `test_layout.LayoutEngineTest.test_should_layout_node_with_children`
+in the schema defined above.

--- a/tests/w3c_test_data/README.md
+++ b/tests/w3c_test_data/README.md
@@ -13,7 +13,7 @@ W3C tests are defined as:
 
 __Do this regularly__:
 
-1. Run `get_w3c_test_data.py`, loop over tests defined in `https://github.com/w3c/csswg-test`:
+1. Run `tests/get_w3c_test_data.py TEST_DIR`, where `TEST_DIR` is the path to a checkout of `https://github.com/w3c/csswg-test`. This will:
     1. Use `Selenium` to launch a browser to interpret CSS and render:
         1. Pull attribute/value pairs as test inputs
         2. Pull width/height/x/y as test outputs

--- a/tests/w3c_test_data/align-content-001.htm.json
+++ b/tests/w3c_test_data/align-content-001.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313079.725126,
+    "w3c_path": "css-flexbox-1/align-content-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content-002.htm.json
+++ b/tests/w3c_test_data/align-content-002.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 26,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 26,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313080.032246,
+    "w3c_path": "css-flexbox-1/align-content-002.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content-003.htm.json
+++ b/tests/w3c_test_data/align-content-003.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 48,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 48,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 74,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 74,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313080.294627,
+    "w3c_path": "css-flexbox-1/align-content-003.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content-004.htm.json
+++ b/tests/w3c_test_data/align-content-004.htm.json
@@ -1,0 +1,148 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 40,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 40,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 79,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 79,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313080.776052,
+    "w3c_path": "css-flexbox-1/align-content-004.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content-005.htm.json
+++ b/tests/w3c_test_data/align-content-005.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 0,
+                    "top": 14,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 150,
+                    "top": 14,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 0,
+                    "top": 64,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 150,
+                    "top": 64,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313081.077563,
+    "w3c_path": "css-flexbox-1/align-content-005.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content-006.htm.json
+++ b/tests/w3c_test_data/align-content-006.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313081.346024,
+    "w3c_path": "css-flexbox-1/align-content-006.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content_center.html.json
+++ b/tests/w3c_test_data/align-content_center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 25,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 75,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 125,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471313081.570241,
+    "w3c_path": "css-flexbox-1/align-content_center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content_flex-end.html.json
+++ b/tests/w3c_test_data/align-content_flex-end.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 100,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 150,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471313081.800279,
+    "w3c_path": "css-flexbox-1/align-content_flex-end.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content_space-around.html.json
+++ b/tests/w3c_test_data/align-content_space-around.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 8,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 75,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 141,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471313082.280046,
+    "w3c_path": "css-flexbox-1/align-content_space-around.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content_space-between.html.json
+++ b/tests/w3c_test_data/align-content_space-between.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 75,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 150,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471313082.537734,
+    "w3c_path": "css-flexbox-1/align-content_space-between.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-content_stretch.html.json
+++ b/tests/w3c_test_data/align-content_stretch.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 66,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 133,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471313082.761988,
+    "w3c_path": "css-flexbox-1/align-content_stretch.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-items-001.htm.json
+++ b/tests/w3c_test_data/align-items-001.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 52,
+                    "left": 0,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "52px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 52,
+                    "left": 150,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "52px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313082.941917,
+    "w3c_path": "css-flexbox-1/align-items-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-items-002.htm.json
+++ b/tests/w3c_test_data/align-items-002.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 51,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 51,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313083.119468,
+    "w3c_path": "css-flexbox-1/align-items-002.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-items-003.htm.json
+++ b/tests/w3c_test_data/align-items-003.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 51,
+                    "left": 0,
+                    "top": 49,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 51,
+                    "left": 150,
+                    "top": 49,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313083.296523,
+    "w3c_path": "css-flexbox-1/align-items-003.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-items-004.htm.json
+++ b/tests/w3c_test_data/align-items-004.htm.json
@@ -1,0 +1,184 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 0,
+                    "top": 15,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 75,
+                    "top": 15,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 150,
+                    "top": 0,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "40px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 225,
+                    "top": 15,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 0,
+                    "top": 65,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 75,
+                    "top": 65,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 150,
+                    "top": 50,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "40px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 225,
+                    "top": 65,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "20px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313083.652698,
+    "w3c_path": "css-flexbox-1/align-items-004.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-items-005.htm.json
+++ b/tests/w3c_test_data/align-items-005.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313083.841191,
+    "w3c_path": "css-flexbox-1/align-items-005.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-self-004.html.json
+++ b/tests/w3c_test_data/align-self-004.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 25,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 50,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 75,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313084.310221,
+    "w3c_path": "css-flexbox-1/align-self-004.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-self-006.html.json
+++ b/tests/w3c_test_data/align-self-006.html.json
@@ -1,0 +1,188 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 20,
+                            "left": 1,
+                            "top": 12,
+                            "width": 27
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 90,
+                    "left": 1,
+                    "top": 10,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "90px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 10,
+                            "left": 31,
+                            "top": 19,
+                            "width": 22
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 50,
+                    "left": 31,
+                    "top": 18,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 30,
+                            "left": 61,
+                            "top": 4,
+                            "width": 27
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 100,
+                    "left": 61,
+                    "top": 1,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 16,
+                            "left": 91,
+                            "top": 15,
+                            "width": 20
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 80,
+                    "left": 91,
+                    "top": 15,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "80px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 102,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313084.740164,
+    "w3c_path": "css-flexbox-1/align-self-006.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-self-010.html.json
+++ b/tests/w3c_test_data/align-self-010.html.json
@@ -1,0 +1,188 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 20,
+                            "left": 1,
+                            "top": 12,
+                            "width": 27
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 90,
+                    "left": 1,
+                    "top": 10,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "90px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 10,
+                            "left": 31,
+                            "top": 19,
+                            "width": 22
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 50,
+                    "left": 31,
+                    "top": 18,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 30,
+                            "left": 61,
+                            "top": 4,
+                            "width": 27
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 100,
+                    "left": 61,
+                    "top": 1,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 16,
+                            "left": 91,
+                            "top": 15,
+                            "width": 20
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "auto",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "auto"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 80,
+                    "left": 91,
+                    "top": 15,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "80px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 102,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313085.319792,
+    "w3c_path": "css-flexbox-1/align-self-010.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-self-011.html.json
+++ b/tests/w3c_test_data/align-self-011.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 25,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 50,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 75,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313085.56031,
+    "w3c_path": "css-flexbox-1/align-self-011.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/align-self-012.html.json
+++ b/tests/w3c_test_data/align-self-012.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 25,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 50,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 75,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313085.799482,
+    "w3c_path": "css-flexbox-1/align-self-012.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-box-justify-content.html.json
+++ b/tests/w3c_test_data/css-box-justify-content.html.json
@@ -1,0 +1,130 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 30,
+                    "left": 34,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "30px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 30,
+                    "left": 88,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "30px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 30,
+                    "left": 142,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "30px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 30,
+                    "left": 196,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "30px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 30,
+                    "left": 250,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "30px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 40,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "40px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313086.141298,
+    "w3c_path": "css-flexbox-1/css-box-justify-content.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-001.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-001.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 24,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241170.294655,
+    "w3c_path": "css-flexbox-1/align-content-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-002.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-002.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 26,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 26,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241170.560094,
+    "w3c_path": "css-flexbox-1/align-content-002.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-003.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-003.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 48,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 48,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 0,
+                    "top": 74,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 26,
+                    "left": 150,
+                    "top": 74,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "26px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241170.797745,
+    "w3c_path": "css-flexbox-1/align-content-003.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-004.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-004.htm.json
@@ -1,0 +1,148 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 40,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 40,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 0,
+                    "top": 79,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 150,
+                    "top": 79,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "21px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241171.190039,
+    "w3c_path": "css-flexbox-1/align-content-004.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-005.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-005.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 0,
+                    "top": 14,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 150,
+                    "top": 14,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 0,
+                    "top": 64,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 22,
+                    "left": 150,
+                    "top": 64,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "22px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241171.427759,
+    "w3c_path": "css-flexbox-1/align-content-005.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content-006.htm.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content-006.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471241171.709706,
+    "w3c_path": "css-flexbox-1/align-content-006.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content_center.html.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content_center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 25,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 75,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 125,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471241171.922931,
+    "w3c_path": "css-flexbox-1/align-content_center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content_flex-end.html.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content_flex-end.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 100,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 150,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471241172.129586,
+    "w3c_path": "css-flexbox-1/align-content_flex-end.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-1_align-content_flex-start.html.json
+++ b/tests/w3c_test_data/css-flexbox-1_align-content_flex-start.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 100,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 80
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "80px"
+        }
+    },
+    "stored_time": 1471241172.321037,
+    "w3c_path": "css-flexbox-1/align-content_flex-start.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column-reverse-wrap-reverse.html.json
+++ b/tests/w3c_test_data/css-flexbox-column-reverse-wrap-reverse.html.json
@@ -1,0 +1,364 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 288,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "288px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313086.912935,
+    "w3c_path": "css-flexbox-1/css-flexbox-column-reverse-wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column-reverse-wrap.html.json
+++ b/tests/w3c_test_data/css-flexbox-column-reverse-wrap.html.json
@@ -1,0 +1,364 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 288,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "288px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313087.777501,
+    "w3c_path": "css-flexbox-1/css-flexbox-column-reverse-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column-reverse.html.json
+++ b/tests/w3c_test_data/css-flexbox-column-reverse.html.json
@@ -1,0 +1,148 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 384,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "384px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313088.085683,
+    "w3c_path": "css-flexbox-1/css-flexbox-column-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column-wrap-reverse.html.json
+++ b/tests/w3c_test_data/css-flexbox-column-wrap-reverse.html.json
@@ -1,0 +1,364 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 288,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "288px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313088.751414,
+    "w3c_path": "css-flexbox-1/css-flexbox-column-wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column-wrap.html.json
+++ b/tests/w3c_test_data/css-flexbox-column-wrap.html.json
@@ -1,0 +1,364 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 16,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 120,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 96,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 72,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 48,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 24,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 32,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "16px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 288,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "288px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313089.672097,
+    "w3c_path": "css-flexbox-1/css-flexbox-column-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-column.html.json
+++ b/tests/w3c_test_data/css-flexbox-column.html.json
@@ -1,0 +1,148 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 120,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 96,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 72,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 48,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 24,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 0,
+                    "top": 0,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "24px"
+                }
+            }
+        ],
+        "position": {
+            "height": 384,
+            "left": 0,
+            "top": 0,
+            "width": 144
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "384px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "144px"
+        }
+    },
+    "stored_time": 1471313090.045969,
+    "w3c_path": "css-flexbox-1/css-flexbox-column.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-height-animation-stretch.html.json
+++ b/tests/w3c_test_data/css-flexbox-height-animation-stretch.html.json
@@ -1,0 +1,207 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [],
+                                "position": {
+                                    "height": 68,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 50
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "65.8333px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "50px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 74,
+                            "left": 0,
+                            "top": 0,
+                            "width": 50
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "74.3px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "50px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [],
+                                "position": {
+                                    "height": 50,
+                                    "left": 50,
+                                    "top": 0,
+                                    "width": 50
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "50px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "50px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 62,
+                            "left": 50,
+                            "top": 0,
+                            "width": 50
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "61.5833px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "50px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [],
+                                "position": {
+                                    "height": 50,
+                                    "left": 100,
+                                    "top": 0,
+                                    "width": 50
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "50px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "50px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 56,
+                            "left": 100,
+                            "top": 0,
+                            "width": 50
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "55.6833px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "50px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [],
+                                "position": {
+                                    "height": 50,
+                                    "left": 150,
+                                    "top": 0,
+                                    "width": 50
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "50px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "50px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 52,
+                            "left": 150,
+                            "top": 0,
+                            "width": 50
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "51.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "50px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 89,
+                    "left": 0,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "85.3px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 95,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "95.3167px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313090.62734,
+    "w3c_path": "css-flexbox-1/css-flexbox-height-animation-stretch.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/css-flexbox-img-expand-evenly.html.json
+++ b/tests/w3c_test_data/css-flexbox-img-expand-evenly.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 2,
+                    "top": 2,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "98px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 102,
+                    "top": 2,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "98px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 202,
+                    "top": 2,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "98px"
+                }
+            }
+        ],
+        "position": {
+            "height": 54,
+            "left": 0,
+            "top": 0,
+            "width": 304
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "50px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313090.893095,
+    "w3c_path": "css-flexbox-1/css-flexbox-img-expand-evenly.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/display-flex-001.htm.json
+++ b/tests/w3c_test_data/display-flex-001.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313091.606298,
+    "w3c_path": "css-flexbox-1/display-flex-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/example.json
+++ b/tests/w3c_test_data/example.json
@@ -1,61 +1,59 @@
-[
-    {
-        "capabilities": {},
-        "node_data": {
-            "children": [
-                {
-                    "children": [],
-                    "position": {
-                        "height": 500,
-                        "left": 0,
-                        "top": 0,
-                        "width": 500
-                    },
-                    "style": {
-                        "height": 500,
-                        "width": 500
-                    }
+{
+    "capabilities": {},
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 500,
+                    "left": 0,
+                    "top": 0,
+                    "width": 500
                 },
-                {
-                    "children": [],
-                    "position": {
-                        "height": 250,
-                        "left": 0,
-                        "top": 500,
-                        "width": 250
-                    },
-                    "style": {
-                        "height": 250,
-                        "width": 250
-                    }
-                },
-                {
-                    "children": [],
-                    "position": {
-                        "height": 125,
-                        "left": 0,
-                        "top": 750,
-                        "width": 125
-                    },
-                    "style": {
-                        "height": 125,
-                        "width": 125
-                    }
+                "style": {
+                    "height": 500,
+                    "width": 500
                 }
-            ],
-            "position": {
-                "height": 1000,
-                "left": 0,
-                "top": 0,
-                "width": 1000
             },
-            "style": {
-                "height": 1000,
-                "width": 1000
+            {
+                "children": [],
+                "position": {
+                    "height": 250,
+                    "left": 0,
+                    "top": 500,
+                    "width": 250
+                },
+                "style": {
+                    "height": 250,
+                    "width": 250
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 125,
+                    "left": 0,
+                    "top": 750,
+                    "width": 125
+                },
+                "style": {
+                    "height": 125,
+                    "width": 125
+                }
             }
+        ],
+        "position": {
+            "height": 1000,
+            "left": 0,
+            "top": 0,
+            "width": 1000
         },
-        "stored_time": 1471228060,
-        "w3c_path": "css-flexbox-1/align-content-001.htm",
-        "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
-    }
-]
+        "style": {
+            "height": 1000,
+            "width": 1000
+        }
+    },
+    "stored_time": 1471228060,
+    "w3c_path": "",
+    "w3c_sha": ""
+}

--- a/tests/w3c_test_data/flex-001.htm.json
+++ b/tests/w3c_test_data/flex-001.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313091.926858,
+    "w3c_path": "css-flexbox-1/flex-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-basis-001.html.json
+++ b/tests/w3c_test_data/flex-basis-001.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 60,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "40px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313092.810543,
+    "w3c_path": "css-flexbox-1/flex-basis-001.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-basis-005.html.json
+++ b/tests/w3c_test_data/flex-basis-005.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313093.177036,
+    "w3c_path": "css-flexbox-1/flex-basis-005.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-basis-006.html.json
+++ b/tests/w3c_test_data/flex-basis-006.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313093.321119,
+    "w3c_path": "css-flexbox-1/flex-basis-006.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-basis-007.html.json
+++ b/tests/w3c_test_data/flex-basis-007.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313093.575031,
+    "w3c_path": "css-flexbox-1/flex-basis-007.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-basis-008.html.json
+++ b/tests/w3c_test_data/flex-basis-008.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "40px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 40,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313094.057498,
+    "w3c_path": "css-flexbox-1/flex-basis-008.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-box-wrap.html.json
+++ b/tests/w3c_test_data/flex-box-wrap.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 120
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "120px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 100,
+                    "width": 120
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "120px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 100,
+                    "width": 120
+                },
+                "style": {
+                    "bottom": "0px",
+                    "height": "100px",
+                    "left": "0px",
+                    "position": "absolute",
+                    "right": "80px",
+                    "top": "100px",
+                    "width": "120px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "200px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313094.298992,
+    "w3c_path": "css-flexbox-1/flex-box-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-container-margin.html.json
+++ b/tests/w3c_test_data/flex-container-margin.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 20,
+                    "top": 20,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 110,
+                    "top": 20,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 200,
+                    "top": 20,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 90,
+            "left": 0,
+            "top": 0,
+            "width": 1224
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "90px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1224px"
+        }
+    },
+    "stored_time": 1471313094.505088,
+    "w3c_path": "css-flexbox-1/flex-container-margin.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-direction-row-vertical.html.json
+++ b/tests/w3c_test_data/flex-direction-row-vertical.html.json
@@ -1,0 +1,186 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 12,
+                            "left": 0,
+                            "top": 0,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "11.55px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 11,
+                            "left": 0,
+                            "top": 12,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "10.6667px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 11,
+                            "left": 0,
+                            "top": 22,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "10.6667px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 12,
+                    "left": 0,
+                    "top": 0,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "11.55px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 11,
+                            "left": 48,
+                            "top": 1,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "10.6667px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 11,
+                            "left": 48,
+                            "top": -10,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "10.6667px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 12,
+                            "left": 48,
+                            "top": -21,
+                            "width": 16
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "11.55px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "16px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 12,
+                    "left": 48,
+                    "top": 0,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "11.55px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 12,
+            "left": 0,
+            "top": 0,
+            "width": 96
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "11.55px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "96px"
+        }
+    },
+    "stored_time": 1471313095.143536,
+    "w3c_path": "css-flexbox-1/flex-direction-row-vertical.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-direction_column-reverse.html.json
+++ b/tests/w3c_test_data/flex-direction_column-reverse.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 150,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 100,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313095.575082,
+    "w3c_path": "css-flexbox-1/flex-direction_column-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-direction_column.html.json
+++ b/tests/w3c_test_data/flex-direction_column.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 100,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313095.817567,
+    "w3c_path": "css-flexbox-1/flex-direction_column.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-direction_row-reverse.html.json
+++ b/tests/w3c_test_data/flex-direction_row-reverse.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 100,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313096.055091,
+    "w3c_path": "css-flexbox-1/flex-direction_row-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-direction_row.html.json
+++ b/tests/w3c_test_data/flex-direction_row.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 100,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313096.31308,
+    "w3c_path": "css-flexbox-1/flex-direction_row.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flexitem-childmargin.html.json
+++ b/tests/w3c_test_data/flex-flexitem-childmargin.html.json
@@ -1,0 +1,114 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 0,
+                            "top": 200,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 300,
+                    "left": 0,
+                    "top": 0,
+                    "width": 1164
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "300px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "1164px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 1164,
+                            "top": 200,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 300,
+                    "left": 1164,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "300px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            }
+        ],
+        "position": {
+            "height": 300,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "300px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313096.550718,
+    "w3c_path": "css-flexbox-1/flex-flexitem-childmargin.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flexitem-percentage-prescation.html.json
+++ b/tests/w3c_test_data/flex-flexitem-percentage-prescation.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 300,
+                    "left": 0,
+                    "top": 0,
+                    "width": 51
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "300px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50.5px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 300,
+                    "left": 51,
+                    "top": 0,
+                    "width": 51
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "300px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50.5px"
+                }
+            }
+        ],
+        "position": {
+            "height": 300,
+            "left": 0,
+            "top": 0,
+            "width": 101
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "300px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "101px"
+        }
+    },
+    "stored_time": 1471313096.715919,
+    "w3c_path": "css-flexbox-1/flex-flexitem-percentage-prescation.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-001.html.json
+++ b/tests/w3c_test_data/flex-flow-001.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 25,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 75,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            }
+        ],
+        "position": {
+            "height": 50,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "50px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313096.941047,
+    "w3c_path": "css-flexbox-1/flex-flow-001.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-002.html.json
+++ b/tests/w3c_test_data/flex-flow-002.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313097.188819,
+    "w3c_path": "css-flexbox-1/flex-flow-002.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-003.html.json
+++ b/tests/w3c_test_data/flex-flow-003.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313097.428792,
+    "w3c_path": "css-flexbox-1/flex-flow-003.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-004.html.json
+++ b/tests/w3c_test_data/flex-flow-004.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 75,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 25,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 25
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "25px"
+                }
+            }
+        ],
+        "position": {
+            "height": 50,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "50px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313097.66834,
+    "w3c_path": "css-flexbox-1/flex-flow-004.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-005.html.json
+++ b/tests/w3c_test_data/flex-flow-005.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313097.902287,
+    "w3c_path": "css-flexbox-1/flex-flow-005.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-006.html.json
+++ b/tests/w3c_test_data/flex-flow-006.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313098.147413,
+    "w3c_path": "css-flexbox-1/flex-flow-006.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-007.html.json
+++ b/tests/w3c_test_data/flex-flow-007.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 25,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 50,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 75,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313098.398095,
+    "w3c_path": "css-flexbox-1/flex-flow-007.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-008.html.json
+++ b/tests/w3c_test_data/flex-flow-008.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313098.633102,
+    "w3c_path": "css-flexbox-1/flex-flow-008.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-009.html.json
+++ b/tests/w3c_test_data/flex-flow-009.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313098.892856,
+    "w3c_path": "css-flexbox-1/flex-flow-009.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-010.html.json
+++ b/tests/w3c_test_data/flex-flow-010.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 75,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 50,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 25,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 25,
+                    "left": 0,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "25px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313099.276549,
+    "w3c_path": "css-flexbox-1/flex-flow-010.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-011.html.json
+++ b/tests/w3c_test_data/flex-flow-011.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313099.510531,
+    "w3c_path": "css-flexbox-1/flex-flow-011.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-flow-012.html.json
+++ b/tests/w3c_test_data/flex-flow-012.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313099.763379,
+    "w3c_path": "css-flexbox-1/flex-flow-012.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-order.html.json
+++ b/tests/w3c_test_data/flex-order.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 200,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 100,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313100.480823,
+    "w3c_path": "css-flexbox-1/flex-order.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-shrink-006.html.json
+++ b/tests/w3c_test_data/flex-shrink-006.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 100
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "100px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 100,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 100,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 100,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 100
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "100px"
+        }
+    },
+    "stored_time": 1471313101.143155,
+    "w3c_path": "css-flexbox-1/flex-shrink-006.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-vertical-align-effect.html.json
+++ b/tests/w3c_test_data/flex-vertical-align-effect.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 20,
+                    "left": 0,
+                    "top": 0,
+                    "width": 139
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13.5px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "133.333px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 13,
+                    "left": 139,
+                    "top": 0,
+                    "width": 13
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "13px"
+                }
+            }
+        ],
+        "position": {
+            "height": 20,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.5px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313101.39482,
+    "w3c_path": "css-flexbox-1/flex-vertical-align-effect.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-wrap-001.htm.json
+++ b/tests/w3c_test_data/flex-wrap-001.htm.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 150,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313101.635933,
+    "w3c_path": "css-flexbox-1/flex-wrap-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-wrap_nowrap.html.json
+++ b/tests/w3c_test_data/flex-wrap_nowrap.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "40px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "40px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "40px"
+                }
+            }
+        ],
+        "position": {
+            "height": 50,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "50px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313101.847897,
+    "w3c_path": "css-flexbox-1/flex-wrap_nowrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-wrap_wrap-reverse.html.json
+++ b/tests/w3c_test_data/flex-wrap_wrap-reverse.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313102.055761,
+    "w3c_path": "css-flexbox-1/flex-wrap_wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flex-wrap_wrap.html.json
+++ b/tests/w3c_test_data/flex-wrap_wrap.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 50,
+                    "top": 0,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 50
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "50px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313102.265954,
+    "w3c_path": "css-flexbox-1/flex-wrap_wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-direction-column-reverse.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-direction-column-reverse.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313102.641001,
+    "w3c_path": "css-flexbox-1/flexbox-flex-direction-column-reverse.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-direction-column.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-direction-column.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313103.030125,
+    "w3c_path": "css-flexbox-1/flexbox-flex-direction-column.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-direction-default.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-direction-default.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313103.425308,
+    "w3c_path": "css-flexbox-1/flexbox-flex-direction-default.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-direction-row-reverse.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-direction-row-reverse.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313103.796537,
+    "w3c_path": "css-flexbox-1/flexbox-flex-direction-row-reverse.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-direction-row.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-direction-row.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313104.186705,
+    "w3c_path": "css-flexbox-1/flexbox-flex-direction-row.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-wrap-default.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-wrap-default.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 120,
+                    "left": 0,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "120px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 120,
+                    "left": 60,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "120px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "60px"
+        }
+    },
+    "stored_time": 1471313104.354276,
+    "w3c_path": "css-flexbox-1/flexbox-flex-wrap-default.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-wrap-flexing.html.json
+++ b/tests/w3c_test_data/flexbox-flex-wrap-flexing.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 150
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "150px"
+        }
+    },
+    "stored_time": 1471313104.524954,
+    "w3c_path": "css-flexbox-1/flexbox-flex-wrap-flexing.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-wrap-nowrap.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-wrap-nowrap.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 120,
+                    "left": 0,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "120px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 120,
+                    "left": 60,
+                    "top": 0,
+                    "width": 60
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "120px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "60px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "60px"
+        }
+    },
+    "stored_time": 1471313104.694034,
+    "w3c_path": "css-flexbox-1/flexbox-flex-wrap-nowrap.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-wrap-wrap-reverse.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-wrap-wrap-reverse.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313105.40959,
+    "w3c_path": "css-flexbox-1/flexbox-flex-wrap-wrap-reverse.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-flex-wrap-wrap.htm.json
+++ b/tests/w3c_test_data/flexbox-flex-wrap-wrap.htm.json
@@ -1,0 +1,202 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 40,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 0,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 40,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 40,
+                    "left": 80,
+                    "top": 80,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "38px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "38px"
+                }
+            }
+        ],
+        "position": {
+            "height": 120,
+            "left": 0,
+            "top": 0,
+            "width": 120
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "120px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "120px"
+        }
+    },
+    "stored_time": 1471313105.889173,
+    "w3c_path": "css-flexbox-1/flexbox-flex-wrap-wrap.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-order-from-lowest.html.json
+++ b/tests/w3c_test_data/flexbox-order-from-lowest.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 84,
+                    "top": 16,
+                    "width": 36
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "35.5167px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 33,
+                    "top": 16,
+                    "width": 51
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "51.0833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 0,
+                    "top": 16,
+                    "width": 33
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "33.2833px"
+                }
+            }
+        ],
+        "position": {
+            "height": 51,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "51.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313106.107351,
+    "w3c_path": "css-flexbox-1/flexbox-order-from-lowest.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox-order-only-flexitems.html.json
+++ b/tests/w3c_test_data/flexbox-order-only-flexitems.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 0,
+                    "top": 2,
+                    "width": 33
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "auto",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "auto"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 37,
+                    "top": 2,
+                    "width": 51
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "auto",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "auto"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 16,
+                    "left": 92,
+                    "top": 2,
+                    "width": 36
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "auto",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "auto"
+                }
+            }
+        ],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313106.345109,
+    "w3c_path": "css-flexbox-1/flexbox-order-only-flexitems.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_absolute-atomic.html.json
+++ b/tests/w3c_test_data/flexbox_absolute-atomic.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 207,
+                    "top": 20,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 660,
+                    "top": -980,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "1586.8px",
+                    "height": "19.2px",
+                    "left": "640px",
+                    "position": "absolute",
+                    "right": "560.05px",
+                    "top": "-1000px",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1033,
+                    "top": 20,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            }
+        ],
+        "position": {
+            "height": 59,
+            "left": 0,
+            "top": 0,
+            "width": 1280
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "59.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1280px"
+        }
+    },
+    "stored_time": 1471313106.563075,
+    "w3c_path": "css-flexbox-1/flexbox_absolute-atomic.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-center.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 49,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313106.771081,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-flexend.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-flexend.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 65,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313106.99987,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-flexend.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-flexstart.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-flexstart.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313107.21589,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-flexstart.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-spacearound.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-spacearound.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 9,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 9,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 57,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313107.444822,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-spacearound.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-spacebetween.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-spacebetween.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 65,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313107.683305,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-spacebetween.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-stretch-2.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-stretch-2.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 17,
+                    "top": 49,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313107.921544,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-stretch-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-content-stretch.html.json
+++ b/tests/w3c_test_data/flexbox_align-content-stretch.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 49,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313108.253434,
+    "w3c_path": "css-flexbox-1/flexbox_align-content-stretch.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-baseline.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-baseline.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 337,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313108.445162,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-baseline.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-center-2.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-center-2.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 25,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 337,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313108.658974,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-center-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-center.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 337,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313108.888844,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-flexend-2.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-flexend-2.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 49,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 337,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313109.09085,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-flexend-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-flexend.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-flexend.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 337,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313109.304779,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-flexend.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-flexstart-2.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-flexstart-2.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313109.504397,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-flexstart-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-flexstart.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-flexstart.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313109.722413,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-flexstart.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-stretch-2.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-stretch-2.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 0,
+                    "left": 0,
+                    "top": 96,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "0px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 128,
+                    "top": 0,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 256,
+                    "top": 0,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 96,
+            "left": 0,
+            "top": 0,
+            "width": 480
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313109.969035,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-stretch-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-items-stretch.html.json
+++ b/tests/w3c_test_data/flexbox_align-items-stretch.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 49,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313110.214939,
+    "w3c_path": "css-flexbox-1/flexbox_align-items-stretch.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-auto.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-auto.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 337,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313110.462714,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-baseline.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-baseline.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 17,
+                    "top": 25,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 25,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313110.669079,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-baseline.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-center.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 64,
+                    "left": 337,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "64px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313110.874139,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-flexend.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-flexend.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 337,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313111.070054,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-flexend.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-flexstart.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-flexstart.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 78,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313111.30491,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-flexstart.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_align-self-stretch.html.json
+++ b/tests/w3c_test_data/flexbox_align-self-stretch.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 17,
+                    "top": 25,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 48,
+                    "left": 177,
+                    "top": 25,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "48px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 337,
+                    "top": 1,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313111.625907,
+    "w3c_path": "css-flexbox-1/flexbox_align-self-stretch.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_block.html.json
+++ b/tests/w3c_test_data/flexbox_block.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313112.082817,
+    "w3c_path": "css-flexbox-1/flexbox_block.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_columns-flexitems-2.html.json
+++ b/tests/w3c_test_data/flexbox_columns-flexitems-2.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 58,
+                    "left": 532,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "57.6px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 58,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "57.6px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313112.350692,
+    "w3c_path": "css-flexbox-1/flexbox_columns-flexitems-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_columns-flexitems.html.json
+++ b/tests/w3c_test_data/flexbox_columns-flexitems.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 14,
+                    "left": 532,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13.5px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 14,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "13.5px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313112.51714,
+    "w3c_path": "css-flexbox-1/flexbox_columns-flexitems.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_columns.html.json
+++ b/tests/w3c_test_data/flexbox_columns.html.json
@@ -1,0 +1,130 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 99,
+                    "top": 0,
+                    "width": 118
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "117.667px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 414,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 651,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 888,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1125,
+                    "top": 0,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            }
+        ],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313112.80089,
+    "w3c_path": "css-flexbox-1/flexbox_columns.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_direction-column-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_direction-column-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 171,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 119,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 207,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "204.8px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313113.048792,
+    "w3c_path": "css-flexbox-1/flexbox_direction-column-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_direction-column.html.json
+++ b/tests/w3c_test_data/flexbox_direction-column.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 119,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 171,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 207,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "204.8px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313113.304263,
+    "w3c_path": "css-flexbox-1/flexbox_direction-column.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_direction-row-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_direction-row-reverse.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 14,
+                    "left": 87,
+                    "top": 0,
+                    "width": 43
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13.5px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "43.3333px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 14,
+                    "left": 43,
+                    "top": 0,
+                    "width": 43
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13.5px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "43.3333px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 14,
+                    "left": 0,
+                    "top": 0,
+                    "width": 43
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "13.5px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "43.3333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 14,
+            "left": 0,
+            "top": 0,
+            "width": 130
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "13.5px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "130px"
+        }
+    },
+    "stored_time": 1471313113.518633,
+    "w3c_path": "css-flexbox-1/flexbox_direction-row-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_display.html.json
+++ b/tests/w3c_test_data/flexbox_display.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 33,
+                    "top": 33,
+                    "width": 1198
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "1198px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 33,
+                    "top": 84,
+                    "width": 1198
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "1198px"
+                }
+            }
+        ],
+        "position": {
+            "height": 136,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "134.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313113.705583,
+    "w3c_path": "css-flexbox-1/flexbox_display.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_first-line.html.json
+++ b/tests/w3c_test_data/flexbox_first-line.html.json
@@ -1,0 +1,184 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 32,
+                    "top": 32,
+                    "width": 42
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 138,
+                    "top": 32,
+                    "width": 192
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "190px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 394,
+                    "top": 32,
+                    "width": 42
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 500,
+                    "top": 32,
+                    "width": 192
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "190px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 32,
+                    "top": 117,
+                    "width": 192
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "190px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 288,
+                    "top": 117,
+                    "width": 42
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 394,
+                    "top": 117,
+                    "width": 192
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "190px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 21,
+                    "left": 650,
+                    "top": 117,
+                    "width": 42
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            }
+        ],
+        "position": {
+            "height": 170,
+            "left": 0,
+            "top": 0,
+            "width": 900
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "170.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "900px"
+        }
+    },
+    "stored_time": 1471313114.333188,
+    "w3c_path": "css-flexbox-1/flexbox_first-line.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313114.592024,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313114.833118,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-1-unitless-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-1-unitless-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313115.087417,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-1-unitless-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313115.82988,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-N-unitless-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-N-unitless-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313116.068342,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-N-unitless-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313116.296257,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 289,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313116.548182,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 257,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 385,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313116.788618,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313115.33449,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313115.583559,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313117.047748,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313117.284093,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313117.519067,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-1-unitless-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-1-unitless-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313117.753545,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-1-unitless-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313118.954641,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-N-unitless-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-N-unitless-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313119.23031,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-N-unitless-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313119.48152,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313119.719894,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 257,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 385,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313119.953131,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313118.201639,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313118.698922,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-1.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-1.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313120.202612,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-1.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313120.553107,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313120.849971,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313121.636008,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313121.881309,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313122.124929,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 257,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 385,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313122.362792,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313121.118303,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313121.380773,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-0-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-0-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 24,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 48,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 80,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313122.59662,
+    "w3c_path": "css-flexbox-1/flexbox_flex-0-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313122.825806,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313123.067799,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313123.801088,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313124.030087,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 289,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313124.257472,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313124.591553,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313123.309377,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313123.544674,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313125.144429,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313125.444025,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313125.699303,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313126.460753,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313126.713277,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313126.959667,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313127.246209,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313125.952136,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313126.221012,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-1.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-1.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313127.527196,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-1.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313127.802821,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313128.05972,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313128.775671,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313129.005485,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313129.241938,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313129.479082,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313128.28966,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313128.540553,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-1-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-1-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313129.729145,
+    "w3c_path": "css-flexbox-1/flexbox_flex-1-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313140.345969,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313141.154474,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313166.797142,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313177.259849,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 289,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313186.669646,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313187.980397,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 81,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313142.620374,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313143.637914,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313189.355305,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313202.268857,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313220.019148,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313266.488622,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313269.942684,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313271.659792,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313276.868295,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313230.387219,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313241.556588,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-1.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-1.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313278.267242,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-1.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-0-unitless.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-0-unitless.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313279.050755,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-0-unitless.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-0.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-0.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313282.487683,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-0.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-N-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-N-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313283.505029,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-N-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313283.776155,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-Npercent-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-Npercent-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 49,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 145,
+                    "top": 17,
+                    "width": 48
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "48px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 194
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "192px"
+        }
+    },
+    "stored_time": 1471313284.075047,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-Npercent-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-Npercent.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-Npercent.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313284.335386,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-Npercent.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-auto-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-auto-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 258
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "256px"
+        }
+    },
+    "stored_time": 1471313282.829443,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-auto-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313283.24472,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-N-N.html.json
+++ b/tests/w3c_test_data/flexbox_flex-N-N.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 161,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 642
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "640px"
+        }
+    },
+    "stored_time": 1471313284.591393,
+    "w3c_path": "css-flexbox-1/flexbox_flex-N-N.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-basis-shrink.html.json
+++ b/tests/w3c_test_data/flexbox_flex-basis-shrink.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 289,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 386
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "384px"
+        }
+    },
+    "stored_time": 1471313130.055778,
+    "w3c_path": "css-flexbox-1/flexbox_flex-basis-shrink.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 129,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 257,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 385,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 130
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "128px"
+        }
+    },
+    "stored_time": 1471313130.289273,
+    "w3c_path": "css-flexbox-1/flexbox_flex-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-natural-mixed-basis-auto.html.json
+++ b/tests/w3c_test_data/flexbox_flex-natural-mixed-basis-auto.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 0,
+                    "top": 0,
+                    "width": 99
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "99.1667px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 99,
+                    "top": 0,
+                    "width": 120
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "120.483px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 220,
+                    "top": 0,
+                    "width": 135
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "134.667px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 354,
+                    "top": 0,
+                    "width": 206
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "205.683px"
+                }
+            }
+        ],
+        "position": {
+            "height": 128,
+            "left": 0,
+            "top": 0,
+            "width": 560
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "560px"
+        }
+    },
+    "stored_time": 1471313284.85278,
+    "w3c_path": "css-flexbox-1/flexbox_flex-natural-mixed-basis-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-natural-mixed-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-natural-mixed-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 0,
+                    "top": 0,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 80,
+                    "top": 0,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 240,
+                    "top": 0,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 400,
+                    "top": 0,
+                    "width": 160
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "160px"
+                }
+            }
+        ],
+        "position": {
+            "height": 128,
+            "left": 0,
+            "top": 0,
+            "width": 560
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "560px"
+        }
+    },
+    "stored_time": 1471313285.097741,
+    "w3c_path": "css-flexbox-1/flexbox_flex-natural-mixed-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-natural-variable-auto-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-natural-variable-auto-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 1,
+                    "top": 1,
+                    "width": 112
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "112px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 113,
+                    "top": 1,
+                    "width": 176
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "176px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 289,
+                    "top": 1,
+                    "width": 112
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "112px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 401,
+                    "top": 1,
+                    "width": 112
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "112px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 514
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "512px"
+        }
+    },
+    "stored_time": 1471313285.34129,
+    "w3c_path": "css-flexbox-1/flexbox_flex-natural-variable-auto-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flex-natural-variable-zero-basis.html.json
+++ b/tests/w3c_test_data/flexbox_flex-natural-variable-zero-basis.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 1,
+                    "top": 1,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 97,
+                    "top": 1,
+                    "width": 288
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "288px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 385,
+                    "top": 1,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 481,
+                    "top": 1,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 578
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "576px"
+        }
+    },
+    "stored_time": 1471313285.611377,
+    "w3c_path": "css-flexbox-1/flexbox_flex-natural-variable-zero-basis.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-column-reverse-wrap-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_flow-column-reverse-wrap-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313286.04517,
+    "w3c_path": "css-flexbox-1/flexbox_flow-column-reverse-wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-column-reverse-wrap.html.json
+++ b/tests/w3c_test_data/flexbox_flow-column-reverse-wrap.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313286.302223,
+    "w3c_path": "css-flexbox-1/flexbox_flow-column-reverse-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-column-wrap-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_flow-column-wrap-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313286.546395,
+    "w3c_path": "css-flexbox-1/flexbox_flow-column-wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-column-wrap.html.json
+++ b/tests/w3c_test_data/flexbox_flow-column-wrap.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313286.796876,
+    "w3c_path": "css-flexbox-1/flexbox_flow-column-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-row-wrap-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_flow-row-wrap-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313287.077205,
+    "w3c_path": "css-flexbox-1/flexbox_flow-row-wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_flow-row-wrap.html.json
+++ b/tests/w3c_test_data/flexbox_flow-row-wrap.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313287.331964,
+    "w3c_path": "css-flexbox-1/flexbox_flow-row-wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_generated-flex.html.json
+++ b/tests/w3c_test_data/flexbox_generated-flex.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 66,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313287.46399,
+    "w3c_path": "css-flexbox-1/flexbox_generated-flex.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_generated-nested-flex.html.json
+++ b/tests/w3c_test_data/flexbox_generated-nested-flex.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 66,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313287.589578,
+    "w3c_path": "css-flexbox-1/flexbox_generated-nested-flex.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_generated.html.json
+++ b/tests/w3c_test_data/flexbox_generated.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 16,
+                    "top": 16,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 64,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313287.747273,
+    "w3c_path": "css-flexbox-1/flexbox_generated.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_inline-abspos.html.json
+++ b/tests/w3c_test_data/flexbox_inline-abspos.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 34
+        },
+        "style": {
+            "bottom": "938.8px",
+            "height": "19.2px",
+            "left": "8px",
+            "position": "absolute",
+            "right": "1237.65px",
+            "top": "8px",
+            "width": "34.35px"
+        }
+    },
+    "stored_time": 1471313287.869169,
+    "w3c_path": "css-flexbox-1/flexbox_inline-abspos.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_inline-float.html.json
+++ b/tests/w3c_test_data/flexbox_inline-float.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 34
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "34.35px"
+        }
+    },
+    "stored_time": 1471313287.986421,
+    "w3c_path": "css-flexbox-1/flexbox_inline-float.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_inline.html.json
+++ b/tests/w3c_test_data/flexbox_inline.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 111
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "111.033px"
+        }
+    },
+    "stored_time": 1471313288.130281,
+    "w3c_path": "css-flexbox-1/flexbox_inline.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_item-bottom-float.html.json
+++ b/tests/w3c_test_data/flexbox_item-bottom-float.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 32,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 128,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 224,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 320,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            }
+        ],
+        "position": {
+            "height": 96,
+            "left": 0,
+            "top": 0,
+            "width": 400
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "400px"
+        }
+    },
+    "stored_time": 1471313288.549782,
+    "w3c_path": "css-flexbox-1/flexbox_item-bottom-float.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_item-float.html.json
+++ b/tests/w3c_test_data/flexbox_item-float.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 32,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 128,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 224,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 320,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            }
+        ],
+        "position": {
+            "height": 96,
+            "left": 0,
+            "top": 0,
+            "width": 1232
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1232px"
+        }
+    },
+    "stored_time": 1471313288.947739,
+    "w3c_path": "css-flexbox-1/flexbox_item-float.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_item-top-float.html.json
+++ b/tests/w3c_test_data/flexbox_item-top-float.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 32,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 128,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 224,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 320,
+                    "top": 32,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            }
+        ],
+        "position": {
+            "height": 96,
+            "left": 0,
+            "top": 0,
+            "width": 400
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "400px"
+        }
+    },
+    "stored_time": 1471313289.201949,
+    "w3c_path": "css-flexbox-1/flexbox_item-top-float.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_item-vertical-align.html.json
+++ b/tests/w3c_test_data/flexbox_item-vertical-align.html.json
@@ -1,0 +1,130 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 33,
+                    "top": 33,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 129,
+                    "top": 33,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 225,
+                    "top": 33,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 321,
+                    "top": 33,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 417,
+                    "top": 33,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "32px"
+                }
+            }
+        ],
+        "position": {
+            "height": 98,
+            "left": 0,
+            "top": 0,
+            "width": 602
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "96px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313289.502814,
+    "w3c_path": "css-flexbox-1/flexbox_item-vertical-align.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-center-overflow.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-center-overflow.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 78,
+                    "left": -34,
+                    "top": 14,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "78px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.4px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 78,
+                    "left": 15,
+                    "top": 14,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "78px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.4px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 78,
+                    "left": 65,
+                    "top": 14,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "78px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.4px"
+                }
+            }
+        ],
+        "position": {
+            "height": 106,
+            "left": 0,
+            "top": 0,
+            "width": 54
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "104px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "52px"
+        }
+    },
+    "stored_time": 1471313289.71219,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-center-overflow.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-center.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 65,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 321,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313289.931552,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-flex-end.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-flex-end.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 113,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 241,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 369,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313290.142808,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-flex-end.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-flex-start.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-flex-start.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 33,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 353,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313290.36385,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-flex-start.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacearound-negative.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacearound-negative.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 9,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 105,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 201,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 274
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "272px"
+        }
+    },
+    "stored_time": 1471313290.575217,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacearound-negative.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacearound-only.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacearound-only.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313290.753782,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacearound-only.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacearound.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacearound.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 33,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 353,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313291.021008,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacearound.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacebetween-negative.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacebetween-negative.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 17,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 113,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 209,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 274
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "272px"
+        }
+    },
+    "stored_time": 1471313291.248568,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacebetween-negative.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacebetween-only.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacebetween-only.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 17,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313291.405968,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacebetween-only.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_justifycontent-spacebetween.html.json
+++ b/tests/w3c_test_data/flexbox_justifycontent-spacebetween.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 17,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 369,
+                    "top": 17,
+                    "width": 96
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "96px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 482
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "480px"
+        }
+    },
+    "stored_time": 1471313291.616332,
+    "w3c_path": "css-flexbox-1/flexbox_justifycontent-spacebetween.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin-auto-overflow-2.html.json
+++ b/tests/w3c_test_data/flexbox_margin-auto-overflow-2.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 192
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "192px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 193,
+                    "top": 17,
+                    "width": 480
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "480px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 514
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "128px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "512px"
+        }
+    },
+    "stored_time": 1471313291.793732,
+    "w3c_path": "css-flexbox-1/flexbox_margin-auto-overflow-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin-auto-overflow.html.json
+++ b/tests/w3c_test_data/flexbox_margin-auto-overflow.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 1,
+                    "top": 17,
+                    "width": 480
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "480px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 481,
+                    "top": 17,
+                    "width": 480
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "480px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 514
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "128px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "512px"
+        }
+    },
+    "stored_time": 1471313292.007203,
+    "w3c_path": "css-flexbox-1/flexbox_margin-auto-overflow.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin-auto.html.json
+++ b/tests/w3c_test_data/flexbox_margin-auto.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 97,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 353,
+                    "top": 17,
+                    "width": 64
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "64px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 514
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "128px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "512px"
+        }
+    },
+    "stored_time": 1471313292.20197,
+    "w3c_path": "css-flexbox-1/flexbox_margin-auto.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin-collapse.html.json
+++ b/tests/w3c_test_data/flexbox_margin-collapse.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1,
+                    "top": 17,
+                    "width": 1278
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "1278px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1,
+                    "top": 68,
+                    "width": 1278
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "1278px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 1280
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1278px"
+        }
+    },
+    "stored_time": 1471313292.384398,
+    "w3c_path": "css-flexbox-1/flexbox_margin-collapse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin-left-ex.html.json
+++ b/tests/w3c_test_data/flexbox_margin-left-ex.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 17,
+                    "top": 17,
+                    "width": 23
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.1px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 72,
+                    "top": 17,
+                    "width": 24
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "23.9833px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 128,
+                    "top": 17,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 96,
+                    "left": 470,
+                    "top": 17,
+                    "width": 27
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "96px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "26.6333px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 514
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "128px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "512px"
+        }
+    },
+    "stored_time": 1471313292.612588,
+    "w3c_path": "css-flexbox-1/flexbox_margin-left-ex.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_margin.html.json
+++ b/tests/w3c_test_data/flexbox_margin.html.json
@@ -1,0 +1,39 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [],
+        "position": {
+            "height": 64,
+            "left": 0,
+            "top": 0,
+            "width": 1232
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1232px"
+        }
+    },
+    "stored_time": 1471313292.735217,
+    "w3c_path": "css-flexbox-1/flexbox_margin.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_nested-flex.html.json
+++ b/tests/w3c_test_data/flexbox_nested-flex.html.json
@@ -1,0 +1,58 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 17,
+                    "top": 17,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 66,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313292.882619,
+    "w3c_path": "css-flexbox-1/flexbox_nested-flex.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_object.html.json
+++ b/tests/w3c_test_data/flexbox_object.html.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 212,
+                    "top": 0,
+                    "width": 208
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "208.283px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 844,
+                    "top": 0,
+                    "width": 208
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "208.283px"
+                }
+            }
+        ],
+        "position": {
+            "height": 19,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "19.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313293.055369,
+    "w3c_path": "css-flexbox-1/flexbox_object.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_order-abspos-space-around.html.json
+++ b/tests/w3c_test_data/flexbox_order-abspos-space-around.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 25,
+                    "top": 1,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 0,
+                    "left": 353,
+                    "top": 1,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "128px",
+                    "height": "0px",
+                    "left": "352px",
+                    "position": "absolute",
+                    "right": "0px",
+                    "top": "0px",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 201,
+                    "top": 1,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 128,
+                    "left": 329,
+                    "top": 1,
+                    "width": 80
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "128px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "80px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 434
+        },
+        "style": {
+            "bottom": "0px",
+            "height": "128px",
+            "left": "0px",
+            "position": "relative",
+            "right": "0px",
+            "top": "0px",
+            "width": "432px"
+        }
+    },
+    "stored_time": 1471313293.303717,
+    "w3c_path": "css-flexbox-1/flexbox_order-abspos-space-around.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_order-box.html.json
+++ b/tests/w3c_test_data/flexbox_order-box.html.json
@@ -1,0 +1,150 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 388,
+                            "top": 34,
+                            "width": 128
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "128px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 548,
+                            "top": 34,
+                            "width": 128
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "128px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 53,
+                    "left": 371,
+                    "top": 17,
+                    "width": 322
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "320px"
+                }
+            },
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 34,
+                            "top": 34,
+                            "width": 128
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "128px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 194,
+                            "top": 34,
+                            "width": 128
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "128px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 53,
+                    "left": 17,
+                    "top": 17,
+                    "width": 322
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "320px"
+                }
+            }
+        ],
+        "position": {
+            "height": 87,
+            "left": 0,
+            "top": 0,
+            "width": 1232
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "85.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1230px"
+        }
+    },
+    "stored_time": 1471313293.610604,
+    "w3c_path": "css-flexbox-1/flexbox_order-box.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_order.html.json
+++ b/tests/w3c_test_data/flexbox_order.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313293.919759,
+    "w3c_path": "css-flexbox-1/flexbox_order.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rowspan-overflow-automatic.html.json
+++ b/tests/w3c_test_data/flexbox_rowspan-overflow-automatic.html.json
@@ -1,0 +1,481 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 16,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 88,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 160,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 232,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 304,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 0,
+                                            "top": 64,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 256,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "256px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 316,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 388,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 460,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 532,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 604,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 0,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 0,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 316,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 388,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 460,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 532,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 604,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 128,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 128,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 128,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 600
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "600px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 600
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313294.942223,
+    "w3c_path": "css-flexbox-1/flexbox_rowspan-overflow-automatic.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rowspan-overflow.html.json
+++ b/tests/w3c_test_data/flexbox_rowspan-overflow.html.json
@@ -1,0 +1,481 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 16,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 88,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 160,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 232,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 304,
+                                                    "top": 80,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 0,
+                                            "top": 64,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 256,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "256px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 316,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 388,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 460,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 532,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 604,
+                                                    "top": 16,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 0,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 0,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 316,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 388,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 460,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 532,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 96,
+                                                    "left": 604,
+                                                    "top": 144,
+                                                    "width": 40
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "96px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "39.95px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 128,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 128,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 128,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 600
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "600px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 600
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313295.976551,
+    "w3c_path": "css-flexbox-1/flexbox_rowspan-overflow.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rowspan.html.json
+++ b/tests/w3c_test_data/flexbox_rowspan.html.json
@@ -1,0 +1,481 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 80,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 131,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 182,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 234,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 285,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 0,
+                                            "top": 64,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 256,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "256px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 16,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 67,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 118,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 170,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 221,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 0,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 0,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 0,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    },
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 144,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 195,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 246,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 298,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 316,
+                                                    "top": 349,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 128,
+                                            "left": 300,
+                                            "top": 128,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "128px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 128,
+                                    "left": 300,
+                                    "top": 128,
+                                    "width": 300
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "128px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "300px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 128,
+                            "left": 0,
+                            "top": 128,
+                            "width": 600
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "128px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "600px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 600
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "600px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 600
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313296.871616,
+    "w3c_path": "css-flexbox-1/flexbox_rowspan.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rtl-direction.html.json
+++ b/tests/w3c_test_data/flexbox_rtl-direction.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1119,
+                    "top": 171,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1119,
+                    "top": 119,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1119,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1119,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 207,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "204.8px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1262px"
+        }
+    },
+    "stored_time": 1471313297.150036,
+    "w3c_path": "css-flexbox-1/flexbox_rtl-direction.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rtl-flow-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_rtl-flow-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313297.443917,
+    "w3c_path": "css-flexbox-1/flexbox_rtl-flow-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rtl-flow.html.json
+++ b/tests/w3c_test_data/flexbox_rtl-flow.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313297.76907,
+    "w3c_path": "css-flexbox-1/flexbox_rtl-flow.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_rtl-order.html.json
+++ b/tests/w3c_test_data/flexbox_rtl-order.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 177,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 33,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 24,
+                    "left": 17,
+                    "top": 89,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "24px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 130,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "128px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313298.096472,
+    "w3c_path": "css-flexbox-1/flexbox_rtl-order.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-abspos.html.json
+++ b/tests/w3c_test_data/flexbox_stf-abspos.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "382px",
+            "height": "256px",
+            "left": "8px",
+            "position": "absolute",
+            "right": "972px",
+            "top": "8px",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313298.425289,
+    "w3c_path": "css-flexbox-1/flexbox_stf-abspos.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-fixpos.html.json
+++ b/tests/w3c_test_data/flexbox_stf-fixpos.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "382px",
+            "height": "256px",
+            "left": "8px",
+            "position": "fixed",
+            "right": "972px",
+            "top": "8px",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313298.730285,
+    "w3c_path": "css-flexbox-1/flexbox_stf-fixpos.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-float.html.json
+++ b/tests/w3c_test_data/flexbox_stf-float.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313299.038663,
+    "w3c_path": "css-flexbox-1/flexbox_stf-float.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-inline-block.html.json
+++ b/tests/w3c_test_data/flexbox_stf-inline-block.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313299.353097,
+    "w3c_path": "css-flexbox-1/flexbox_stf-inline-block.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-caption.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-caption.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313299.670097,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-caption.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-cell.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-cell.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313300.009806,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-cell.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-row-group.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-row-group.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313300.306593,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-row-group.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-row.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-row.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313300.619722,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-row.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-singleline-2.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-singleline-2.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 0,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 40,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 80,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 120,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 160,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 51,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 51,
+            "left": 0,
+            "top": 0,
+            "width": 0
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "51.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "0px"
+        }
+    },
+    "stored_time": 1471313300.917613,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-singleline-2.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table-singleline.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table-singleline.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 0,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 40,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 80,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 120,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 160,
+                            "top": 16,
+                            "width": 40
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "39.95px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 51,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "51.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 51,
+            "left": 0,
+            "top": 0,
+            "width": 0
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "51.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "0px"
+        }
+    },
+    "stored_time": 1471313301.320388,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table-singleline.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_stf-table.html.json
+++ b/tests/w3c_test_data/flexbox_stf-table.html.json
@@ -1,0 +1,149 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 16,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 67,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 118,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 170,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 19,
+                            "left": 16,
+                            "top": 221,
+                            "width": 200
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "19.2px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "200px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313302.100699,
+    "w3c_path": "css-flexbox-1/flexbox_stf-table.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_table-fixed-layout.html.json
+++ b/tests/w3c_test_data/flexbox_table-fixed-layout.html.json
@@ -1,0 +1,334 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 16,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 67,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 118,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 170,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 221,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 256,
+                                            "left": 0,
+                                            "top": 0,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "256px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 256,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 0
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "256px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "0px"
+                                }
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 16,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 67,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 118,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 170,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            },
+                                            {
+                                                "children": [],
+                                                "position": {
+                                                    "height": 19,
+                                                    "left": 16,
+                                                    "top": 221,
+                                                    "width": 200
+                                                },
+                                                "style": {
+                                                    "bottom": "auto",
+                                                    "height": "19.2px",
+                                                    "left": "auto",
+                                                    "position": "static",
+                                                    "right": "auto",
+                                                    "top": "auto",
+                                                    "width": "200px"
+                                                }
+                                            }
+                                        ],
+                                        "position": {
+                                            "height": 256,
+                                            "left": 0,
+                                            "top": 0,
+                                            "width": 300
+                                        },
+                                        "style": {
+                                            "bottom": "auto",
+                                            "height": "256px",
+                                            "left": "auto",
+                                            "position": "static",
+                                            "right": "auto",
+                                            "top": "auto",
+                                            "width": "300px"
+                                        }
+                                    }
+                                ],
+                                "position": {
+                                    "height": 256,
+                                    "left": 0,
+                                    "top": 0,
+                                    "width": 0
+                                },
+                                "style": {
+                                    "bottom": "auto",
+                                    "height": "256px",
+                                    "left": "auto",
+                                    "position": "static",
+                                    "right": "auto",
+                                    "top": "auto",
+                                    "width": "0px"
+                                }
+                            }
+                        ],
+                        "position": {
+                            "height": 256,
+                            "left": 0,
+                            "top": 0,
+                            "width": 0
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "256px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "0px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 256,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "256px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            }
+        ],
+        "position": {
+            "height": 256,
+            "left": 0,
+            "top": 0,
+            "width": 0
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "256px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "0px"
+        }
+    },
+    "stored_time": 1471313302.760103,
+    "w3c_path": "css-flexbox-1/flexbox_table-fixed-layout.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_visibility-collapse-line-wrapping.html.json
+++ b/tests/w3c_test_data/flexbox_visibility-collapse-line-wrapping.html.json
@@ -1,0 +1,148 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1,
+                    "top": 17,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 301,
+                    "top": 17,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 601,
+                    "top": 1,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 601,
+                    "top": 1,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 1,
+                    "top": 68,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 301,
+                    "top": 68,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 602
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "600px"
+        }
+    },
+    "stored_time": 1471313303.078803,
+    "w3c_path": "css-flexbox-1/flexbox_visibility-collapse-line-wrapping.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_visibility-collapse.html.json
+++ b/tests/w3c_test_data/flexbox_visibility-collapse.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 33,
+                    "top": 33,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 105,
+                    "top": 1,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 137,
+                    "top": 33,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            }
+        ],
+        "position": {
+            "height": 85,
+            "left": 0,
+            "top": 0,
+            "width": 1280
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "83.2px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1278px"
+        }
+    },
+    "stored_time": 1471313303.312264,
+    "w3c_path": "css-flexbox-1/flexbox_visibility-collapse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_width-overflow.html.json
+++ b/tests/w3c_test_data/flexbox_width-overflow.html.json
@@ -1,0 +1,130 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": -96,
+                    "top": 16,
+                    "width": 32
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "31.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": -64,
+                    "top": 16,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": -24,
+                    "top": 16,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 16,
+                    "top": 16,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 32,
+                    "left": 56,
+                    "top": 16,
+                    "width": 40
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "32px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "39.95px"
+                }
+            }
+        ],
+        "position": {
+            "height": 64,
+            "left": 0,
+            "top": 0,
+            "width": 0
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "64px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "0px"
+        }
+    },
+    "stored_time": 1471313303.601397,
+    "w3c_path": "css-flexbox-1/flexbox_width-overflow.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_wrap-long.html.json
+++ b/tests/w3c_test_data/flexbox_wrap-long.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 288
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "288px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 119,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 156,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "153.6px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313303.920802,
+    "w3c_path": "css-flexbox-1/flexbox_wrap-long.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_wrap-reverse.html.json
+++ b/tests/w3c_test_data/flexbox_wrap-reverse.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313304.222221,
+    "w3c_path": "css-flexbox-1/flexbox_wrap-reverse.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_wrap.html.json
+++ b/tests/w3c_test_data/flexbox_wrap.html.json
@@ -1,0 +1,112 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 17,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 17,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 19,
+                    "left": 177,
+                    "top": 68,
+                    "width": 128
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "19.2px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "128px"
+                }
+            }
+        ],
+        "position": {
+            "height": 104,
+            "left": 0,
+            "top": 0,
+            "width": 322
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "102.4px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "320px"
+        }
+    },
+    "stored_time": 1471313304.481814,
+    "w3c_path": "css-flexbox-1/flexbox_wrap.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/flexbox_writing_mode_vertical_lays_out_contents_from_top_to_bottom.html.json
+++ b/tests/w3c_test_data/flexbox_writing_mode_vertical_lays_out_contents_from_top_to_bottom.html.json
@@ -1,0 +1,131 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 100,
+                            "top": 0,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 100,
+                            "top": 100,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 0,
+                            "top": 0,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    },
+                    {
+                        "children": [],
+                        "position": {
+                            "height": 100,
+                            "left": 0,
+                            "top": 100,
+                            "width": 100
+                        },
+                        "style": {
+                            "bottom": "auto",
+                            "height": "100px",
+                            "left": "auto",
+                            "position": "static",
+                            "right": "auto",
+                            "top": "auto",
+                            "width": "100px"
+                        }
+                    }
+                ],
+                "position": {
+                    "height": 200,
+                    "left": 0,
+                    "top": 0,
+                    "width": 200
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "200px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 1264
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "1264px"
+        }
+    },
+    "stored_time": 1471313304.759101,
+    "w3c_path": "css-flexbox-1/flexbox_writing_mode_vertical_lays_out_contents_from_top_to_bottom.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content-001.htm.json
+++ b/tests/w3c_test_data/justify-content-001.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 74,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313305.277226,
+    "w3c_path": "css-flexbox-1/justify-content-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content-002.htm.json
+++ b/tests/w3c_test_data/justify-content-002.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 75,
+                    "top": 0,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313305.469585,
+    "w3c_path": "css-flexbox-1/justify-content-002.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content-003.htm.json
+++ b/tests/w3c_test_data/justify-content-003.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 225,
+                    "top": 0,
+                    "width": 75
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "75px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313305.646506,
+    "w3c_path": "css-flexbox-1/justify-content-003.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content-004.htm.json
+++ b/tests/w3c_test_data/justify-content-004.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 224,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313305.870662,
+    "w3c_path": "css-flexbox-1/justify-content-004.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content-005.htm.json
+++ b/tests/w3c_test_data/justify-content-005.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 37,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 187,
+                    "top": 0,
+                    "width": 76
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "76px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313306.076009,
+    "w3c_path": "css-flexbox-1/justify-content-005.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content_center.html.json
+++ b/tests/w3c_test_data/justify-content_center.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 55,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 85,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 115,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313306.297979,
+    "w3c_path": "css-flexbox-1/justify-content_center.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content_flex-end.html.json
+++ b/tests/w3c_test_data/justify-content_flex-end.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 110,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 140,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 170,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313306.517927,
+    "w3c_path": "css-flexbox-1/justify-content_flex-end.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content_flex-start.html.json
+++ b/tests/w3c_test_data/justify-content_flex-start.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 0,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 30,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 60,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313306.750004,
+    "w3c_path": "css-flexbox-1/justify-content_flex-start.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content_space-around.html.json
+++ b/tests/w3c_test_data/justify-content_space-around.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 18,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 85,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 152,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313306.96915,
+    "w3c_path": "css-flexbox-1/justify-content_space-around.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/justify-content_space-between.html.json
+++ b/tests/w3c_test_data/justify-content_space-between.html.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 0,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 85,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 200,
+                    "left": 170,
+                    "top": 0,
+                    "width": 30
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "200px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "30px"
+                }
+            }
+        ],
+        "position": {
+            "height": 200,
+            "left": 0,
+            "top": 0,
+            "width": 200
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "200px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "200px"
+        }
+    },
+    "stored_time": 1471313307.198075,
+    "w3c_path": "css-flexbox-1/justify-content_space-between.html",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/order-001.htm.json
+++ b/tests/w3c_test_data/order-001.htm.json
@@ -1,0 +1,76 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 150,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 100,
+                    "left": 0,
+                    "top": 0,
+                    "width": 150
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "100px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "150px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313307.39079,
+    "w3c_path": "css-flexbox-1/order-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}

--- a/tests/w3c_test_data/visibility-collapse-001.htm.json
+++ b/tests/w3c_test_data/visibility-collapse-001.htm.json
@@ -1,0 +1,94 @@
+{
+    "capabilities": {
+        "acceptSslCerts": true,
+        "applicationCacheEnabled": true,
+        "browserName": "firefox",
+        "cssSelectorsEnabled": true,
+        "databaseEnabled": true,
+        "handlesAlerts": true,
+        "javascriptEnabled": true,
+        "locationContextEnabled": true,
+        "nativeEvents": false,
+        "platform": "Darwin",
+        "rotatable": false,
+        "takesScreenshot": true,
+        "version": "48.0",
+        "webStorageEnabled": true
+    },
+    "node_data": {
+        "children": [
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 0,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 0,
+                    "left": 0,
+                    "top": 50,
+                    "width": 0
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "0px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "0px"
+                }
+            },
+            {
+                "children": [],
+                "position": {
+                    "height": 50,
+                    "left": 0,
+                    "top": 50,
+                    "width": 300
+                },
+                "style": {
+                    "bottom": "auto",
+                    "height": "50px",
+                    "left": "auto",
+                    "position": "static",
+                    "right": "auto",
+                    "top": "auto",
+                    "width": "300px"
+                }
+            }
+        ],
+        "position": {
+            "height": 100,
+            "left": 0,
+            "top": 0,
+            "width": 300
+        },
+        "style": {
+            "bottom": "auto",
+            "height": "100px",
+            "left": "auto",
+            "position": "static",
+            "right": "auto",
+            "top": "auto",
+            "width": "300px"
+        }
+    },
+    "stored_time": 1471313307.89634,
+    "w3c_path": "css-flexbox-1/visibility-collapse-001.htm",
+    "w3c_sha": "7be59dd2ba04892c68f9978bd601935a23375473"
+}


### PR DESCRIPTION
This PR adds tests that run Colosseum against the W3C CSS flex box test suite, and compares them against results obtained from Firefox using Selenium. A script to regenerate the test data is also included.