### PR TITLE
Add project urls to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,11 @@ setup(
         'Topic :: Software Development',
         'Topic :: Software Development :: User Interfaces',
     ],
-    test_suite='tests'
+    test_suite='tests',
+    package_urls={
+        'Funding': 'https://pybee.org/contributing/membership/',
+        'Documentation': 'https://colosseum.readthedocs.io/',
+        'Tracker': 'https://github.com/pybee/colosseum/issues',
+        'Source': 'https://github.com/pybee/colosseum',
+    },
 )


### PR DESCRIPTION
setup.py now defines a spec for project urls, which results in a more
informative pypi page and helps downstream consumers of project information.