### PR TITLE
Updated contribute.rst to update script name

### DIFF
--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -19,7 +19,7 @@ fork::
     $ mkdir beeware
     $ cd beeware
     $ python3 -m venv venv
-    $ source venv/bin/activate.sh
+    $ source venv/bin/activate
     $ git clone git@github.com:<your github username>/colosseum.git
     $ cd colosseum
 


### PR DESCRIPTION
In Python 3.6.5, the activate.sh file does not exist, but has been replaced by a file "activate" without the extension.